### PR TITLE
Adding permissions to release job from main workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,3 +12,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: write # To publish a GitHub release.
+      issues: write # To comment on released issues.
+      pull-requests: write # To comment on released pull requests.
+      id-token: write # To enable use of OIDC for npm provenance.


### PR DESCRIPTION
Attempting to fix error surfaced by previous Merge triggered action https://github.com/jimbojw/memorelay/actions/runs/4959850555:

```
Invalid workflow file: .github/workflows/main.yml#L11
The workflow is not valid. .github/workflows/main.yml (Line: 11, Col: 3): Error calling workflow
  'jimbojw/memorelay/.github/workflows/release.yml@478a34dd76f62ff8750ca045529338d5705e94a0'.
  The nested job 'Release' is requesting 'contents: write, issues: write, pull-requests: write,
  id-token: write', but is only allowed 'contents: read, issues: none, pull-requests: none, id-token: none'.
```